### PR TITLE
Change volley newRequestQueue method signature to allow us to inject httpStack

### DIFF
--- a/src/main/java/com/android/volley/toolbox/AdaptedHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/AdaptedHttpStack.java
@@ -78,4 +78,9 @@ class AdaptedHttpStack extends BaseHttpStack {
                 (int) apacheResp.getEntity().getContentLength(),
                 apacheResp.getEntity().getContent());
     }
+
+    @Override
+    public void updateConnectionType(String connectionType) {
+        // Not supported for AdaptedHttpStack.
+    }
 }

--- a/src/main/java/com/android/volley/toolbox/BaseHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/BaseHttpStack.java
@@ -90,4 +90,9 @@ public abstract class BaseHttpStack implements HttpStack {
 
         return apacheResponse;
     }
+
+    /**
+     * This allows us to notify the stack of any network connectivity changes.
+     */
+    public abstract void updateConnectionType(String connectionType);
 }

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -347,4 +347,9 @@ public class HurlStack extends BaseHttpStack {
         out.write(body);
         out.close();
     }
+
+    @Override
+    public void updateConnectionType(String connectionType) {
+        this.connectionType = connectionType;
+    }
 }

--- a/src/main/java/com/android/volley/toolbox/OkStack.java
+++ b/src/main/java/com/android/volley/toolbox/OkStack.java
@@ -51,6 +51,7 @@ public class OkStack extends BaseHttpStack {
         client = new OkHttpClient();
     }
 
+    @Override
     public void updateConnectionType(String connectionType) {
         this.connectionType = connectionType;
     }

--- a/src/main/java/com/android/volley/toolbox/OkStack.java
+++ b/src/main/java/com/android/volley/toolbox/OkStack.java
@@ -51,6 +51,10 @@ public class OkStack extends BaseHttpStack {
         client = new OkHttpClient();
     }
 
+    public void updateConnectionType(String connectionType) {
+        this.connectionType = connectionType;
+    }
+
     private Map<String, String> getVikiHeaders(int retryCount) {
         Map<String, String> additionalHeaders = new HashMap<>();
         additionalHeaders.put("X-Viki-app-ver", appVersion);
@@ -64,7 +68,6 @@ public class OkStack extends BaseHttpStack {
             additionalHeaders.put("X-Viki-test", String.valueOf(sendTestHeader));
         return additionalHeaders;
     }
-
 
     @Override
     public HttpResponse executeRequest(Request<?> request, Map<String, String> additionalHeaders) throws IOException, AuthFailureError {

--- a/src/main/java/com/android/volley/toolbox/Volley.java
+++ b/src/main/java/com/android/volley/toolbox/Volley.java
@@ -34,6 +34,8 @@ public class Volley {
     /** Default on-disk cache directory. */
     private static final String DEFAULT_CACHE_DIR = "volley";
 
+    private static BaseHttpStack httpStack;
+
     /**
      * Creates a default instance of the worker pool and calls {@link RequestQueue#start()} on it.
      *
@@ -56,19 +58,24 @@ public class Volley {
      * @return A started {@link RequestQueue} instance.
      */
     public static RequestQueue newRequestQueue(Context context) {
-        BaseHttpStack httpStack = newOkStack(context, false);
-        return newRequestQueue(context, httpStack);
+        return newRequestQueue(context, false);
     }
 
-    /**
-     * Use this when we want to inject the httpStack
-     */
-    public static RequestQueue newRequestQueue(Context context, BaseHttpStack httpStack) {
+    public static RequestQueue newRequestQueue(Context context, boolean isTest) {
+        if (httpStack == null) {
+            httpStack = newHttpStack(context, isTest);
+        }
         Network network = new BasicNetwork(httpStack);
         return newRequestQueue(context, network);
     }
 
-    public static OkStack newOkStack(Context context, boolean isTest) {
+    public static void updateConnectionType(String connectionType) {
+        if (httpStack != null) {
+            httpStack.updateConnectionType(connectionType);
+        }
+    }
+
+    private static BaseHttpStack newHttpStack(Context context, boolean isTest) {
         String versionName = "";
         try {
             String packageName = context.getPackageName();


### PR DESCRIPTION
This allows the caller to initialize and hold a reference to the httpStack before passing it to newRequestQueue.

We can have the caller update the connectionType of httpStack when it receives a notification from broadcast receiver that network connectivity has changed.